### PR TITLE
Cn 217/missing translation

### DIFF
--- a/src/app/component/dynamic-elements/dynamic-scheduler/dynamic-scheduler.component.ts
+++ b/src/app/component/dynamic-elements/dynamic-scheduler/dynamic-scheduler.component.ts
@@ -1533,9 +1533,26 @@ export class DynamicSchedulerComponent implements OnInit, OnDestroy {
     );
     if(editorHeaderTitleElement) {
       if(editorHeaderTitleElement.innerHTML === "New Event") {
-        editorHeaderTitleElement.innerHTML = this.language.successUpdateTitle;
+        editorHeaderTitleElement.innerHTML = this.language.newEventTitle;
       } else if (editorHeaderTitleElement.innerHTML === "Edit Event") {
-        editorHeaderTitleElement.innerHTML = this.language.successUpdateTitle;
+        editorHeaderTitleElement.innerHTML = this.language.editEventTitle;
+      }
+    }
+    let editorFooter = document.querySelector(
+      "#_dialog_wrapper > .e-footer-content"
+    );
+    if(editorFooter) {
+      let deleteBtn = editorFooter.querySelector("button.e-event-delete");
+      let cancelBtn = editorFooter.querySelector("button.e-event-cancel");
+      let saveBtn = editorFooter.querySelector("button.e-event-save");
+      if(deleteBtn) {
+        deleteBtn.innerHTML = this.language.delete;
+      }
+      if(cancelBtn) {
+        cancelBtn.innerHTML = this.language.cancel;
+      }
+      if(saveBtn) {
+        saveBtn.innerHTML = this.language.save;
       }
     }
   }

--- a/src/app/component/dynamic-elements/dynamic-scheduler/dynamic-scheduler.component.ts
+++ b/src/app/component/dynamic-elements/dynamic-scheduler/dynamic-scheduler.component.ts
@@ -1094,6 +1094,7 @@ export class DynamicSchedulerComponent implements OnInit, OnDestroy {
 
   onPopupOpen(args): void {
     console.log(args);
+    this.updateEventModalLanguage();
     if (
       (!this.checkConditionForEvent(args) &&
         this.type === this.userType.patient) ||
@@ -1524,6 +1525,19 @@ export class DynamicSchedulerComponent implements OnInit, OnDestroy {
         console.log(this.adminUser);
       }
     });
+  }
+
+  private updateEventModalLanguage() {
+    let editorHeaderTitleElement = document.querySelector(
+      "#_dialog_wrapper > #_dialog_wrapper_dialog-header > #_dialog_wrapper_title > .e-title-text"
+    );
+    if(editorHeaderTitleElement) {
+      if(editorHeaderTitleElement.innerHTML === "New Event") {
+        editorHeaderTitleElement.innerHTML = this.language.successUpdateTitle;
+      } else if (editorHeaderTitleElement.innerHTML === "Edit Event") {
+        editorHeaderTitleElement.innerHTML = this.language.successUpdateTitle;
+      }
+    }
   }
 
   // load holidays defined by clinic and holidays defined by selected clinic template (if there is some)
@@ -3497,7 +3511,6 @@ export class DynamicSchedulerComponent implements OnInit, OnDestroy {
   onActionBegin(args: ActionEventArgs) {
     console.log(args);
     console.log(window.innerWidth);
-
     if (
       window.innerWidth > 992 ||
       this.eventMoveConfirm ||

--- a/src/assets/configuration/scheme/translation.json
+++ b/src/assets/configuration/scheme/translation.json
@@ -485,6 +485,12 @@
             "noStoreSelectedIndicatorText": {
                 "type": "string"
             },
+            "newEventTitle": {
+                "type": "string"
+            },
+            "editEventTitle": {
+                "type": "string"
+            },
             "refreshEventToolbar": {
                 "type": "string"
             },
@@ -3224,6 +3230,19 @@
                         },
                         {
                             "key": "noStoreSelectedIndicatorText"
+                        }
+                    ]
+                },
+                {
+                    "type": "div",
+                    "display": "flex",
+                    "flex-direction": "row",
+                    "items": [
+                        {
+                            "key": "newEventTitle"
+                        },
+                        {
+                            "key": "editEventTitle"
                         }
                     ]
                 }


### PR DESCRIPTION
When user double clicks on calendar or double click on some calendar event 'Edit event' or 'New event' modal opens. Event modals title and footer button texts are displayed in current language of the page.

![image](https://user-images.githubusercontent.com/116258543/202145072-dfa70106-aabc-4c0e-b61a-36adea06d7b1.png)

For Save, Cancel and Delete button are already used existing same names language keys, and for 'Edit event' and 'New event' titles in header keys next translations are added:
Translations:
Serbian
newEvent: Novi događaj
editEvent:  Uredite događaj

English
newEvent: New event
editEvent: Edit event

German
newEvent: Neues Event
editEvent: Ereignis bearbeiten

Slovenian
newEvent: Nov dogodek
editEvent: Uredi dogodek

Croatia
newEvent: Novi događaj
editEvent: Uredi događaj

Italian
newEvent: Nuovo evento
editEvent: Modifica evento
 