### PR TITLE
Cn 188/display message for empty calendar

### DIFF
--- a/src/app/component/dynamic-elements/dynamic-scheduler/dynamic-scheduler.component.html
+++ b/src/app/component/dynamic-elements/dynamic-scheduler/dynamic-scheduler.component.html
@@ -300,13 +300,16 @@
           </div>
           <div class="left-panel" [style.height]="height">
             <div class="overview-scheduler">
-              <div *ngIf="!this.selectedStoreId" class="d-flex-center-column p-3 height-100">
+              <div *ngIf="loading" class="d-flex-center-column p-3 height-100">
+                <div class="fa fa-2x fa-spinner fa-spin"></div>
+              </div>
+              <div *ngIf="!loading && !isValidStoreSelected" class="d-flex-center-column p-3 height-100">
                 <i class="fa fa-search"></i>
                 <span>
                   {{this.language.noStoreSelectedIndicatorText}}
                 </span>
               </div>
-              <ejs-schedule *ngIf="!loading && sharedCalendarResources" #scheduleObj
+              <ejs-schedule *ngIf="!loading && sharedCalendarResources && isValidStoreSelected" #scheduleObj
                 cssClass="e-control schedule-overview table" height="100%" [(currentView)]="currentView"
                 [dateFormat]="dateFormatScheduler" [group]="value ? group : []" [showWeekNumber]="true"
                 [eventSettings]="eventSettings" [allowKeyboardInteraction]="

--- a/src/app/component/dynamic-elements/dynamic-scheduler/dynamic-scheduler.component.html
+++ b/src/app/component/dynamic-elements/dynamic-scheduler/dynamic-scheduler.component.html
@@ -300,6 +300,12 @@
           </div>
           <div class="left-panel" [style.height]="height">
             <div class="overview-scheduler">
+              <div *ngIf="!this.selectedStoreId" class="d-flex-center-column p-3 height-100">
+                <i class="fa fa-search"></i>
+                <span>
+                  {{this.language.noStoreSelectedIndicatorText}}
+                </span>
+              </div>
               <ejs-schedule *ngIf="!loading && sharedCalendarResources" #scheduleObj
                 cssClass="e-control schedule-overview table" height="100%" [(currentView)]="currentView"
                 [dateFormat]="dateFormatScheduler" [group]="value ? group : []" [showWeekNumber]="true"

--- a/src/app/component/dynamic-elements/dynamic-scheduler/dynamic-scheduler.component.ts
+++ b/src/app/component/dynamic-elements/dynamic-scheduler/dynamic-scheduler.component.ts
@@ -241,7 +241,6 @@ export class DynamicSchedulerComponent implements OnInit, OnDestroy {
   changedInvoiceID: any;
   checkIfInputValid = checkIfInputValid;
   checkIfInputValueValid = checkIfInputValueValid;
-  noStoreSelectedToastrId: number;
 
   public generateEvents(): Object[] {
     const eventData: Object[] = [];
@@ -1500,21 +1499,6 @@ export class DynamicSchedulerComponent implements OnInit, OnDestroy {
 
   private initData() {
     this.initializationData();
-    if (!this.selectedStoreId) {
-      this.displayInfoMessageEmptyCalendar();
-    }
-  }
-
-  private displayInfoMessageEmptyCalendar() {
-    this.noStoreSelectedToastrId = this.toastr.info(
-      this.language.noStoreSelectedIndicatorText,
-      this.language.noStoreSelectedIndicatorTitle,
-      {
-        timeOut: 0,
-        extendedTimeOut: 0,
-        closeButton: true,
-      }
-    ).toastId;
   }
 
   public loadUser(): void {
@@ -2573,9 +2557,6 @@ export class DynamicSchedulerComponent implements OnInit, OnDestroy {
           )
         );
       }
-      if (this.noStoreSelectedToastrId) {
-        this.toastr.clear(this.noStoreSelectedToastrId);
-      }
       this.sharedCalendarResources = this.value;
       this.getTaskForSelectedUsers(this.value);
       this.getUserInCompany(event);
@@ -2583,9 +2564,6 @@ export class DynamicSchedulerComponent implements OnInit, OnDestroy {
     } else {
       this.value = null;
       if (event !== undefined) {
-        if (this.noStoreSelectedToastrId) {
-          this.toastr.clear(this.noStoreSelectedToastrId);
-        }
         this.service
           .getTasksForStore(event, this.id, this.type)
           .subscribe((data) => {
@@ -3119,9 +3097,6 @@ export class DynamicSchedulerComponent implements OnInit, OnDestroy {
     this.value = null;
     this.allEvents = [];
     this.sharedCalendarResources = null;
-    if (!this.selectedStoreId) {
-      this.displayInfoMessageEmptyCalendar();
-    }
   }
 
   public createFormGroup(args): FormGroup {

--- a/src/assets/configuration/scheme/translation.json
+++ b/src/assets/configuration/scheme/translation.json
@@ -479,9 +479,6 @@
             "confirmEventMove": {
                 "type": "string"
             },
-            "noStoreSelectedIndicatorTitle": {
-                "type": "string"
-            },
             "noStoreSelectedIndicatorText": {
                 "type": "string"
             },
@@ -3224,9 +3221,6 @@
                         },
                         {
                             "key": "confirmEventMove"
-                        },
-                        {
-                            "key": "noStoreSelectedIndicatorTitle"
                         },
                         {
                             "key": "noStoreSelectedIndicatorText"

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -18027,6 +18027,10 @@ kendo-window {
   width: 100%;
 }
 
+.height-100 {
+  height: 100%;
+}
+
 .display-inline-block {
   display: inline-block;
 }
@@ -19413,6 +19417,13 @@ select:invalid {
 
 .d-flex {
   display: flex !important;
+}
+
+.d-flex-center-column {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
 }
 
 .nav {


### PR DESCRIPTION
Removed toast when calendar is empty and message is directly displayed inside calendar div.
Also added spinner while data are loading for calendar.
How to reproduce:
1. Open calendar page
2. Select some clinic in filters option
3. If clinic is selected in filters option, calendar data is displayed
4. Remove selected clinic from filters option
5. If no clinic is selected, next message gets displayed:
![image](https://user-images.githubusercontent.com/116258543/202518616-7419b887-5132-4fbb-b262-6dfdff276994.png)

