### PR TITLE
Cn 66/no active event since filter

### DIFF
--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -6476,19 +6476,21 @@ router.post("/getFilteredRecipients", function (req, res) {
           "c.id not in (select t.customer_id from tasks t where t.start > now()) and";
       }
 
+      let queryString = "select distinct c.* from customers c join " +
+      table +
+      " sm on c.storeId = sm.superadmin join store s on c.storeId = s.superadmin " +
+      joinTable +
+      " where " +
+      excludeQuery +
+      checkAdditionalQuery +
+      " and c.active = 1 and c.storeId = " +
+      Number(req.body.superadmin) +
+      " and (" +
+      question +
+      ")";
+      console.log(queryString);
       conn.query(
-        "select distinct c.* from customers c join " +
-          table +
-          " sm on c.storeId = sm.superadmin join store s on c.storeId = s.superadmin " +
-          joinTable +
-          " where " +
-          excludeQuery +
-          checkAdditionalQuery +
-          " and c.active = 1 and c.storeId = " +
-          Number(req.body.superadmin) +
-          " and (" +
-          question +
-          ")",
+        queryString,
         function (err, rows) {
           conn.release();
           if (err) return err;

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -6406,6 +6406,14 @@ function getSqlQueryMultiSelect(body) {
     }
   }
 
+  if(body.noEventSinceCheckbox && body.noEventSinceDate) {
+    if(question) {
+      question += ` and CAST(t.end AS DATE) < CAST('${body.noEventSinceDate}' AS DATE)`
+    } else {
+      question = ` CAST(t.end AS DATE) < CAST('${body.noEventSinceDate}' AS DATE)`
+    }
+  }
+
   console.log(question);
 
   return question;
@@ -6421,7 +6429,8 @@ function getJoinTable(body) {
     body.start ||
     body.end ||
     body.creator_id ||
-    body.store
+    body.store ||
+    body.noEventSinceCheckbox
   ) {
     joinTable += " join tasks t on c.id = t.customer_id";
   }
@@ -6444,6 +6453,10 @@ router.post("/getFilteredRecipients", function (req, res) {
         res.json(err);
       }
       var question = getSqlQueryMultiSelect(req.body);
+      if(!question || question.length === 0) {
+        return res.status(400).send('Invalid data send!');
+      }
+      console.log(req.body);
       var joinTable = getJoinTable(req.body);
       console.log('joinTable: ', joinTable);
       var table = "";

--- a/src/app/component/dashboard/marketing/massive-sms/massive-sms.component.ts
+++ b/src/app/component/dashboard/marketing/massive-sms/massive-sms.component.ts
@@ -145,6 +145,13 @@ export class MassiveSmsComponent implements OnInit, FormGuardData {
             this.language.needToConfigurationParams
           );
         }
+      }, (error) => {
+        console.log(error);
+        this.recipients.close();
+        this.helpService.warningToastr(
+          "",
+          this.language.needToConfigurationParams
+        );
       });
   }
 

--- a/src/app/component/dashboard/marketing/massive-sms/massive-sms.component.ts
+++ b/src/app/component/dashboard/marketing/massive-sms/massive-sms.component.ts
@@ -136,9 +136,9 @@ export class MassiveSmsComponent implements OnInit, FormGuardData {
     this.dynamicService
       .callApiPost("/api/getFilteredRecipients", this.changeData)
       .subscribe((data) => {
-        if (data && data["length"] > 0) {
+        if (data) {
           this.allRecipients = data;
-        } else {
+        } else if(!data) {
           this.recipients.close();
           this.helpService.warningToastr(
             "",

--- a/src/app/component/dynamic-elements/dynamic-forms/dynamic-forms.component.html
+++ b/src/app/component/dynamic-elements/dynamic-forms/dynamic-forms.component.html
@@ -1,15 +1,14 @@
 <form
   [formGroup]="form"
   (submit)="handleSubmit($event)"
-  (change)="getIsFormDirty()"
-  (click)="sendValue()"
 >
-  <ng-container
-    *ngFor="let field of config"
-    dynamicField
-    [config]="field"
-    [group]="form"
-  >
+  <ng-container *ngFor="let field of config">
+    <ng-container 
+      dynamicField
+      [config]="field"
+      [group]="form"
+      *ngIf="!field.condition || (field.condition && field.condition.value)">
+    </ng-container>
   </ng-container>
 </form>
 <app-dynamic-confirm-dialog

--- a/src/app/component/dynamic-elements/dynamic-forms/models/field-config.ts
+++ b/src/app/component/dynamic-elements/dynamic-forms/models/field-config.ts
@@ -28,4 +28,8 @@ export interface FieldConfig {
   onLabel?: string;
   offLabel?: string;
   allowCustom?: boolean;
+  condition?: {
+    fieldName: string;
+    value?: any;
+  }
 }

--- a/src/assets/configuration/administarator/massive-sms.json
+++ b/src/assets/configuration/administarator/massive-sms.json
@@ -50,7 +50,6 @@
     "label": "noEventSinceDate",
     "field": "noEventSinceDate",
     "required": true,
-    "maxDate": "currentDate",
     "condition": {
       "fieldName": "noEventSinceCheckbox",
       "value": false

--- a/src/assets/configuration/administarator/massive-sms.json
+++ b/src/assets/configuration/administarator/massive-sms.json
@@ -36,6 +36,27 @@
     "field": "excludeCustomersWithEvents"
   },
   {
+    "type": "checkbox",
+    "width": "col-md-12",
+    "name": "noEventSinceCheckbox",
+    "label": "noEventSinceCheckbox",
+    "field": "noEventSinceCheckbox"
+  },
+  {
+    "type": "datepicker",
+    "width": "col-md-12",
+    "format": "dd.MM.yyyy",
+    "name": "noEventSinceDate",
+    "label": "noEventSinceDate",
+    "field": "noEventSinceDate",
+    "required": true,
+    "maxDate": "currentDate",
+    "condition": {
+      "fieldName": "noEventSinceCheckbox",
+      "value": false
+    }
+  },
+  {
     "type": "datepicker",
     "width": "col-md-6",
     "format": "dd.MM.yyyy",

--- a/src/assets/configuration/scheme/translation.json
+++ b/src/assets/configuration/scheme/translation.json
@@ -2299,6 +2299,12 @@
             "excludeCustomersWithEvents": {
                 "type": "string"
             },
+            "noEventSinceCheckbox": {
+                "type": "string"
+            },
+            "noEventSinceDate": {
+                "type": "string"
+            },
             "chooseImage": {
                 "type": "string"
             },
@@ -6739,6 +6745,19 @@
                         },
                         {
                             "key": "excludeCustomersWithEvents"
+                        }
+                    ]
+                },
+                {
+                    "type": "div",
+                    "display": "flex",
+                    "flex-direction": "row",
+                    "items": [
+                        {
+                            "key": "noEventSinceCheckbox"
+                        },
+                        {
+                            "key": "noEventSinceDate"
                         }
                     ]
                 },


### PR DESCRIPTION
When opening 'Mailing SMS' page we have additinal check option. When it's option get's checked, additional date input field is shown as on picture below:
![image](https://user-images.githubusercontent.com/116258543/203424962-7d72b8a3-41b5-4140-bda4-f46f39cfbbc0.png)
After adding date and click on button 'SMS send' user can see list of all recipients with no events since set date.
![image](https://user-images.githubusercontent.com/116258543/203425384-deb20304-499f-4faf-a859-d7d2df864516.png)
